### PR TITLE
fix: use hcl markup in nomad application example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ environments:
 ```
 ### application.nomad
 
-```json
+```hcl
 job "application-{{ .Environment.name }}" {
   type        = "system"
   region      = "global"


### PR DESCRIPTION
Changing the json tag to hcl to prevents this syntax highlighting errors on readme.

![Screen Shot 2021-06-03 at 20 51 24](https://user-images.githubusercontent.com/10285080/120725981-78341e80-c4ad-11eb-84e7-9d1ae4c8fdd7.png)
