### PR TITLE
A first step to decoupling DynamoDB from logging

### DIFF
--- a/command/deploy.go
+++ b/command/deploy.go
@@ -39,8 +39,11 @@ func (c *DeployCommand) Synopsis() string {
 }
 
 func (c *DeployCommand) Run(args []string) int {
-	log := &logger.DynamoLogger{}
-	log.Init()
+	log, err := logger.NewDynamoLogger()
+	if err != nil {
+		fmt.Println(err.Error())
+		return 1
+	}
 
 	executionID := uuid.NewV4().String()
 	curUser, _ := user.Current()

--- a/commands.go
+++ b/commands.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	"github.com/mitchellh/cli"
-
 	"github.com/pagarme/deployer/command"
 )
 
 func Commands() map[string]cli.CommandFactory {
 	return map[string]cli.CommandFactory{
 		"deploy": func() (cli.Command, error) {
-			return &command.DeployCommand{}, nil
+			return command.NewDeployCommand()
 		},
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,6 @@ github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/nomad v0.5.6 h1:RU6x/F1PRqaikSnz7w9eRqIWYU8s5Zfj4dzlQZV0PWs=
 github.com/hashicorp/nomad v0.5.6/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
-github.com/hashicorp/nomad v0.6.0 h1:ldm80dMeepB9a8ymSw5x3vZh3rwLwupqUDWHULFDGFA=
-github.com/hashicorp/nomad v0.6.0/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
 github.com/hashicorp/raft v1.0.0 h1:htBVktAOtGs4Le5Z7K8SF5H2+oWsQFYVmOgH5loro7Y=
 github.com/hashicorp/raft v1.0.0/go.mod h1:DVSAWItjLjTOkVbSpWQ0j0kUADIvDaCtBxIcbNAQLkI=
 github.com/hashicorp/serf v0.8.2-0.20170708011918-e39abe475740 h1:GVQL9sMniy3lzOCmRJnfDrLW6oyjSo44iV3I2DTEqLU=
@@ -104,7 +102,6 @@ github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFW
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
-github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452 h1:hOY53G+kBFhbYFpRVxHl5eS7laP6B1+Cq+Z9Dry1iMU=
@@ -152,7 +149,6 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190213061140-3a22650c66bd h1:HuTn7WObtcDo9uEEU7rEqL0jYthdXAmZ6PP+meazmaU=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/logger/command.go
+++ b/logger/command.go
@@ -1,13 +1,5 @@
 package logger
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-)
-
 type CommandLog struct {
 	Username     string   `json:"username"`
 	Timestamp    string   `json:"timestamp"`
@@ -16,26 +8,4 @@ type CommandLog struct {
 	Status       string   `json:"status"`
 	StatusReason string   `json:"statusReason"`
 	ExecutionID  string   `json:"executionId"`
-}
-
-func (d *DynamoLogger) LogCommand(command CommandLog) error {
-	av, err := dynamodbattribute.MarshalMap(command)
-	if err != nil {
-		fmt.Printf("An error occured when parsing command: %s\n", err)
-		os.Exit(1)
-	}
-
-	input := &dynamodb.PutItemInput{
-		Item:      av,
-		TableName: d.Table,
-	}
-
-	_, err = d.Svc.PutItem(input)
-	if err != nil {
-		fmt.Println("Got error calling PutItem:")
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
-
-	return nil
 }

--- a/logger/command.go
+++ b/logger/command.go
@@ -4,8 +4,12 @@ type CommandLog struct {
 	Username     string   `json:"username"`
 	Timestamp    string   `json:"timestamp"`
 	Command      string   `json:"command"`
-	Args         []string `json:"args"`
 	Status       string   `json:"status"`
 	StatusReason string   `json:"statusReason"`
 	ExecutionID  string   `json:"executionId"`
+	Args         []string `json:"args"`
+}
+
+type Logger interface {
+	LogCommand(command *CommandLog) error
 }

--- a/logger/dynamodb.go
+++ b/logger/dynamodb.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
 type DynamoLogger struct {
@@ -37,4 +38,26 @@ func (d *DynamoLogger) Init() {
 
 	d.Svc = dynamodb.New(session)
 	d.Table = aws.String(dynamoTable)
+}
+
+func (d *DynamoLogger) LogCommand(command CommandLog) error {
+	av, err := dynamodbattribute.MarshalMap(command)
+	if err != nil {
+		fmt.Printf("An error occured when parsing command: %s\n", err)
+		os.Exit(1)
+	}
+
+	input := &dynamodb.PutItemInput{
+		Item:      av,
+		TableName: d.Table,
+	}
+
+	_, err = d.Svc.PutItem(input)
+	if err != nil {
+		fmt.Println("Got error calling PutItem:")
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	return nil
 }

--- a/logger/dynamodb.go
+++ b/logger/dynamodb.go
@@ -1,13 +1,21 @@
 package logger
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrorDeployerRegionUndefined      = errors.New("DEPLOYER_AWS_REGION must be defined")
+	ErrorDeployerDynamoTableUndefined = errors.New("DEPLOYER_DYNAMODB_TABLE must be defined")
+	ErrorOccurredWhenStartingSession  = errors.New("An error occurred when starting the AWS Session")
+	ErrorParsingCommands              = errors.New("An error occurred when parsing command")
+	ErrorCallingPutItem               = errors.New("Got error calling PutItem")
 )
 
 type DynamoLogger struct {
@@ -15,38 +23,10 @@ type DynamoLogger struct {
 	Table *string
 }
 
-func (d *DynamoLogger) Init() {
-	awsRegion, ok := os.LookupEnv("DEPLOYER_AWS_REGION")
-	if !ok {
-		fmt.Printf("DEPLOYER_AWS_REGION must be defined")
-		os.Exit(1)
-	}
-
-	dynamoTable, ok := os.LookupEnv("DEPLOYER_DYNAMODB_TABLE")
-	if !ok {
-		fmt.Printf("DEPLOYER_DYNAMODB_TABLE must be defined")
-		os.Exit(1)
-	}
-
-	config := &aws.Config{
-		Region: aws.String(awsRegion),
-	}
-
-	ses, err := session.NewSession(config)
-	if err != nil {
-		fmt.Printf("An error occured when starting the AWS Session: %s\n", err)
-		os.Exit(1)
-	}
-
-	d.Svc = dynamodb.New(ses)
-	d.Table = aws.String(dynamoTable)
-}
-
 func (d *DynamoLogger) LogCommand(command CommandLog) error {
 	av, err := dynamodbattribute.MarshalMap(command)
 	if err != nil {
-		fmt.Printf("An error occured when parsing command: %s\n", err)
-		os.Exit(1)
+		return errors.Wrap(err, ErrorParsingCommands.Error())
 	}
 
 	input := &dynamodb.PutItemInput{
@@ -56,10 +36,35 @@ func (d *DynamoLogger) LogCommand(command CommandLog) error {
 
 	_, err = d.Svc.PutItem(input)
 	if err != nil {
-		fmt.Println("Got error calling PutItem:")
-		fmt.Println(err.Error())
-		os.Exit(1)
+		return errors.Wrap(err, ErrorCallingPutItem.Error())
 	}
 
 	return nil
+}
+
+func NewDynamoLogger() (*DynamoLogger, error) {
+	awsRegion, ok := os.LookupEnv("DEPLOYER_AWS_REGION")
+	if !ok {
+		return nil, ErrorDeployerRegionUndefined
+	}
+
+	dynamoTable, ok := os.LookupEnv("DEPLOYER_DYNAMODB_TABLE")
+	if !ok {
+		return nil, ErrorDeployerDynamoTableUndefined
+	}
+
+	config := &aws.Config{
+		Region: aws.String(awsRegion),
+	}
+
+	ses, err := session.NewSession(config)
+	if err != nil {
+		return nil, errors.Wrap(err, ErrorOccurredWhenStartingSession.Error())
+	}
+
+	d := &DynamoLogger{}
+	d.Svc = dynamodb.New(ses)
+	d.Table = aws.String(dynamoTable)
+
+	return d, nil
 }

--- a/logger/dynamodb.go
+++ b/logger/dynamodb.go
@@ -28,15 +28,17 @@ func (d *DynamoLogger) Init() {
 		os.Exit(1)
 	}
 
-	session, err := session.NewSession(&aws.Config{
+	config := &aws.Config{
 		Region: aws.String(awsRegion),
-	})
+	}
+
+	ses, err := session.NewSession(config)
 	if err != nil {
 		fmt.Printf("An error occured when starting the AWS Session: %s\n", err)
 		os.Exit(1)
 	}
 
-	d.Svc = dynamodb.New(session)
+	d.Svc = dynamodb.New(ses)
 	d.Table = aws.String(dynamoTable)
 }
 

--- a/logger/dynamodb.go
+++ b/logger/dynamodb.go
@@ -23,7 +23,7 @@ type DynamoLogger struct {
 	Table *string
 }
 
-func (d *DynamoLogger) LogCommand(command CommandLog) error {
+func (d *DynamoLogger) LogCommand(command *CommandLog) error {
 	av, err := dynamodbattribute.MarshalMap(command)
 	if err != nil {
 		return errors.Wrap(err, ErrorParsingCommands.Error())

--- a/main.go
+++ b/main.go
@@ -10,10 +10,10 @@ import (
 )
 
 func main() {
-	os.Exit(Run(os.Args[1:]))
+	os.Exit(run(os.Args[1:]))
 }
 
-func Run(args []string) int {
+func run(args []string) int {
 	commands := Commands()
 
 	cli := &cli.CLI{
@@ -23,7 +23,6 @@ func Run(args []string) int {
 	}
 
 	exitCode, err := cli.Run()
-
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error executing CLI: %s\n", err.Error())
 		return 1


### PR DESCRIPTION
This PR introduces a `Logger` interface that can be used as an intercept point to allow alternative logging strategies. This change will not resolve the Dynamo coupling but paves the way for that.